### PR TITLE
missing trailing comma in make_option tuple

### DIFF
--- a/elasticstack/management/commands/show_document.py
+++ b/elasticstack/management/commands/show_document.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
             action='store',
             dest='using',
             default='default',
-            help='The Haystack backend to use'))
+            help='The Haystack backend to use'),)
 
     def handle(self, *args, **options):
         try:


### PR DESCRIPTION
On line 21 of elasticstack.managment.commants.show_document.py there was a missing trailing comma. This caused the "tuple" to be of type instance. Hence trying to add it (+) to BaseCommand.option_list will cause an error. This variable option_list is now similar to to that in show_mapping.py

PS thanks for elasticstack....very useful.