### PR TITLE
Add ngram search analyzer setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,11 @@ file::
 Now all your analyzed fields, except for nGram fields, will be analyzed using
 `synonym_analyzer`.
 
+If you want to specify a custom search_analyzer for nGram/EdgeNgram fields,
+define it with the `ELASTICSEARCH_DEFAULT_NGRAM_SEARCH_ANALYZER` settings::
+
+    ELASTICSEARCH_DEFAULT_NGRAM_SEARCH_ANALYZER = 'standard'
+
 Field based analysis
 --------------------
 

--- a/elasticstack/fields.py
+++ b/elasticstack/fields.py
@@ -42,6 +42,7 @@ class ConfigurableFieldMixin(object):
 
     def __init__(self, **kwargs):
         self.analyzer = kwargs.pop('analyzer', None)
+        self.search_analyzer = kwargs.pop('search_analyzer', None)
         if self.analyzer is None:
             raise ValueError("Configurable fields must have an analyzer type")
         super(ConfigurableFieldMixin, self).__init__(**kwargs)


### PR DESCRIPTION
This is a rudimentary attempt at adding search_analyzer capability to elasticstack.  This is specifically to workaround how haystack handles ngram searches, detailed in [issue 1057](https://github.com/django-haystack/django-haystack/issues/1057).

What this PR does:
* Adds an ELATISCSEARCH_DEFAULT_NGRAM_SEARCH_ANALYZER to define a search analyzer to override the ngram/edgengram default for ALL ngram/edgengram fields

What this PR does NOT do:
* Allow overriding of search_analyzer for non-ngram fields
* Allow overriding of individual ngram fields
* Allow overriding of the index_analyzer field

It certainly wouldn't be hard to do the last three bullet points, but they weren't required for my needs.