### PR TITLE
Added configurable index mapping per index

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,11 +36,11 @@ ElasticSearch in mind.
 
 For more background see the blog post `Stretching Haystack's ElasticSearch Backend <http://www.wellfireinteractive.com/blog/custom-haystack-elasticsearch-backend/>`_.
 
-Configurable index mapping
---------------------------
+Global configurable index mapping
+---------------------------------
 
 The search mapping provided by Haystack's ElasticSearch backend includes brief
-but sensible defaults for nGram analysis. You can add change these settings or
+but sensible defaults for nGram analysis. You can globaly add change these settings or
 add your own mappings by providing a mapping dictionary using
 `ELASTICSEARCH_INDEX_SETTINGS` in your settings file. This example takes the
 default mapping and adds a synonym analyzer::
@@ -129,6 +129,58 @@ If you want to specify a custom search_analyzer for nGram/EdgeNgram fields,
 define it with the `ELASTICSEARCH_DEFAULT_NGRAM_SEARCH_ANALYZER` settings::
 
     ELASTICSEARCH_DEFAULT_NGRAM_SEARCH_ANALYZER = 'standard'
+
+Configurable index mapping per index
+------------------------------------
+
+Alternatively you can configure index mapping per index. This is usefull for multilanguage index settup.
+In this case `HAYSTACK_CONNECTION` contains key `SETTINGS_NAME` have to match with name in `ELASTICSEARCH_INDEX_SETTINGS`::
+
+
+    HAYSTACK_CONNECTIONS = {
+        'default': {
+            'ENGINE': 'elasticstack.backends.ConfigurableElasticSearchEngine',
+            'URL': env_var('HAYSTACK_URL', 'http://127.0.0.1:9200/'),
+            'INDEX_NAME': 'haystack',
+            'SETTINGS_NAME': 'cs',
+            'DEFAULT_ANALYZER': 'czech_hunspell',
+            'DEFAULT_NGRAM_SEARCH_ANALYZER': 'standard',
+        },
+    }
+
+    ELASTICSEARCH_INDEX_SETTINGS = {
+        'cs': {
+            "settings": {
+                "analysis": {
+                    "analyzer": {
+                        "czech_hunspell": {
+                            "type": "custom",
+                            "tokenizer": "standard",
+                            "filter": ["stopwords_CZ", "lowercase", "hunspell_CZ", "stopwords_CZ", "remove_duplicities"]
+                        }
+                    },
+                    "filter": {
+                        "stopwords_CZ": {
+                            "type": "stop",
+                            "stopwords": ["právě", "že", "test", "_czech_"],
+                            "ignore_case": True
+                        },
+                        "hunspell_CZ": {
+                            "type": "hunspell",
+                            "locale": "cs_CZ",
+                            "dedup": True,
+                            "recursion_level": 0
+                        },
+                        "remove_duplicities": {
+                            "type": "unique",
+                            "only_on_same_position": True
+                        },
+                    }
+                }
+            }
+        },
+    }
+
 
 Field based analysis
 --------------------

--- a/docs/mappings.rst
+++ b/docs/mappings.rst
@@ -182,6 +182,77 @@ Adding this mapping in and of itself does nothing more than make your new
 analyzer available. To use it you either need to change your
 `ELASTICSEARCH_DEFAULT_ANALYZER` or specify the analyzer in the search index field.
 
+
+Custom analyzers and index settings per index
+=============================================
+
+Global configurable index mapping is great when all your indexes share same configuration.
+In case of multiple language index configuration you need set settings per index.
+In following we show how to configure application for two language separated indexes (czech and italian)::
+
+
+HAYSTACK_CONNECTIONS = {
+    'default': {
+        'ENGINE': 'elasticstack.backends.ConfigurableElasticSearchEngine',
+        'URL': 'http://127.0.0.1:9200/',
+        'INDEX_NAME': 'default',
+        'SETTINGS_NAME': 'default',
+        'DEFAULT_ANALYZER': 'snowball',
+    },
+    'default_cs': {
+        'ENGINE': 'elasticstack.backends.ConfigurableElasticSearchEngine',
+        'URL': 'http://127.0.0.1:9200/',
+        'INDEX_NAME': 'default_cs',
+        'SETTINGS_NAME': 'cs',
+        'DEFAULT_ANALYZER': 'czech_hunspell',
+    },
+    'default_it': {
+        'ENGINE': 'elasticstack.backends.ConfigurableElasticSearchEngine',
+        'URL': 'http://127.0.0.1:9200/',
+        'INDEX_NAME': 'default_it',
+        'SETTINGS_NAME': 'default',
+        'DEFAULT_ANALYZER': 'italian',
+    },
+}
+
+ELASTICSEARCH_INDEX_SETTINGS = {
+    'cs': {
+        "settings": {
+            "analysis": {
+                "analyzer": {
+                    "czech_hunspell": {
+                        "type": "custom",
+                        "tokenizer": "standard",
+                        "filter": ["stopwords_CZ", "lowercase", "hunspell_CZ", "stopwords_CZ", "remove_duplicities"]
+                    }
+                },
+                "filter": {
+                    "stopwords_CZ": {
+                        "type": "stop",
+                        "stopwords": ["_czech_"],
+                        "ignore_case": True
+                    },
+                    "hunspell_CZ": {
+                        "type": "hunspell",
+                        "locale": "cs_CZ",
+                        "dedup": True,
+                        "recursion_level": 0
+                    },
+                    "remove_duplicities": {
+                        "type": "unique",
+                        "only_on_same_position": True
+                    },
+                }
+            }
+        }
+    },
+}
+
+.. note::
+    Czech configures hunspell dictionary. For this example you need to
+    `install it <https://www.elastic.co/guide/en/elasticsearch/guide/current/hunspell.html>`_
+
+
 Realizing custom changes
 ========================
 


### PR DESCRIPTION
Pull request for #17

Two variantion of settings - global (backward compatibility) and per index configuration. It is not possible to combine these settings types (ImproperlyConfigured exception raised with comprehensible description).
